### PR TITLE
Hotfix: Assets ordering by weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-32](https://github.com/itk-dev/cfia/pull/32)
+  * Added weight to cfia theme assets
+
 ## [2.1.9] - 2025-03-05
 
 * [PR-29](https://github.com/itk-dev/cfia/pull/29)

--- a/web/themes/custom/cfia/cfia.libraries.yml
+++ b/web/themes/custom/cfia/cfia.libraries.yml
@@ -1,4 +1,4 @@
 global-styling:
   css:
     component:
-      css/style.css: {}
+      css/style.css: { weight: 95 }


### PR DESCRIPTION
#### Link to ticket

N/A

#### Description

As of drupal 10.4, ordering of assets has changed, which caused the sites theme to loose priority. This PR restores this priority by setting a weight on its assets.

#### Screenshot of the result

N/A

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
