### PR TITLE
4006: Add permission to content editor to allow file upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+* [PR-35](https://github.com/itk-dev/cfia/pull/35)
+  * Update permission to allow content editor to upload images
+
 ## [2.1.11] - 2025-03-12
 
 * [PR-34](https://github.com/itk-dev/cfia/pull/34)

--- a/config/sync/user.role.content_editor.yml
+++ b/config/sync/user.role.content_editor.yml
@@ -3,6 +3,8 @@ langcode: en
 status: true
 dependencies:
   config:
+    - entity_browser.browser.browse_files
+    - entity_browser.browser.browse_files_modal
     - filter.format.basic_html
     - node.type.article
     - node.type.blog_post
@@ -21,6 +23,8 @@ dependencies:
   module:
     - comment
     - contextual
+    - dropzonejs
+    - entity_browser
     - file
     - filter
     - fontawesome
@@ -41,6 +45,8 @@ weight: 2
 is_admin: false
 permissions:
   - 'access administration pages'
+  - 'access browse_files entity browser pages'
+  - 'access browse_files_modal entity browser pages'
   - 'access content overview'
   - 'access contextual links'
   - 'access files overview'
@@ -109,6 +115,7 @@ permissions:
   - 'delete terms in category_blog'
   - 'delete terms in category_case'
   - 'delete terms in tags'
+  - 'dropzone upload files'
   - 'edit any article content'
   - 'edit any blog_post content'
   - 'edit any case content'


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/#/tickets/showTicket/4006

#### Description

Added permission to allow file upload in media browser with JS extension for upload.

#### Screenshot of the result

N/A

#### Checklist

- [x] My code is covered by test cases.
- [x] My code passes our test (all our tests).
- [x] My code passes our static analysis suite.
- [x] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change
should be exempt from the list.

#### Additional comments or questions

PS. Customer has accepted and test this solution.
